### PR TITLE
use relative path

### DIFF
--- a/wxParse/html2json.js
+++ b/wxParse/html2json.js
@@ -13,8 +13,8 @@ var __placeImgeUrlHttps = "https";
 var __emojisReg = '';
 var __emojisBaseSrc = '';
 var __emojis = {};
-var wxDiscode = require('wxDiscode.js');
-var HTMLParser = require('htmlparser.js');
+var wxDiscode = require('./wxDiscode.js');
+var HTMLParser = require('./htmlparser.js');
 // Empty Elements - HTML 5
 var empty = makeMap("area,base,basefont,br,col,frame,hr,img,input,link,meta,param,embed,command,keygen,source,track,wbr");
 // Block Elements - HTML 5

--- a/wxParse/wxParse.js
+++ b/wxParse/wxParse.js
@@ -12,8 +12,8 @@
 /**
  * utils函数引入
  **/
-import showdown from 'showdown.js';
-import HtmlToJson from 'html2json.js';
+import showdown from './showdown.js';
+import HtmlToJson from './html2json.js';
 /**
  * 配置及公有属性
  **/


### PR DESCRIPTION
CommonJS规范中，不以'./'或者'/'的require会加载安装模块，而不是相对模块。