### PR TITLE
Update htmlparser.js

### DIFF
--- a/wxParse/htmlparser.js
+++ b/wxParse/htmlparser.js
@@ -78,8 +78,13 @@ function HTMLParser(html, handler) {
 
 			if (chars) {
 				index = html.indexOf("<");
-
-				var text = index < 0 ? html : html.substring(0, index);
+                                var text = ''
+				while (index === 0) {
+                                  text += "<";
+                                  html = html.substring(1);
+                                  index = html.indexOf("<");
+				}
+				text += index < 0 ? html : html.substring(0, index);
 				html = index < 0 ? "" : html.substring(index);
 
 				if (handler.chars)

--- a/wxParse/htmlparser.js
+++ b/wxParse/htmlparser.js
@@ -78,7 +78,7 @@ function HTMLParser(html, handler) {
 
 			if (chars) {
 				index = html.indexOf("<");
-                                var text = ''
+				var text = ''
 				while (index === 0) {
                                   text += "<";
                                   html = html.substring(1);
@@ -160,11 +160,12 @@ function HTMLParser(html, handler) {
 			var pos = 0;
 
 		// Find the closest opened tag of the same type
-		else
+		else {
+			tagName = tagName.toLowerCase();
 			for (var pos = stack.length - 1; pos >= 0; pos--)
 				if (stack[pos] == tagName)
 					break;
-
+		}
 		if (pos >= 0) {
 			// Close all the open elements, up the stack
 			for (var i = stack.length - 1; i >= pos; i--)


### PR DESCRIPTION
修复有单独的不是html标签的<的解析失败的问题
修复endTag 标签也要转为小写字母与startTag一致