### PR TITLE
修改让没有host的img链接能添加host

### DIFF
--- a/wxParse/html2json.js
+++ b/wxParse/html2json.js
@@ -13,6 +13,7 @@
  */
 
 var __placeImgeUrlHttps = "https";
+var __host ="http://127.0.0.1";
 var __emojisReg = '';
 var __emojisBaseSrc = '';
 var __emojis = {};
@@ -128,6 +129,7 @@ function html2json(html, bindName) {
                 node.imgIndex = results.images.length;
                 var imgUrl = node.attr.src;
                 imgUrl = wxDiscode.urlToHttpUrl(imgUrl, __placeImgeUrlHttps);
+                imgUrl = wxDiscode.urlAddHost(imgUrl, __host);
                 node.attr.src = imgUrl;
                 node.from = bindName;
                 results.images.push(node);

--- a/wxParse/wxDiscode.js
+++ b/wxParse/wxDiscode.js
@@ -199,8 +199,25 @@ function urlToHttpUrl(url,rep){
     }
     return  url;
 }
+function urlAddHost(url,host){
+    let pat1=new RegExp("^http");
+    let result= pat1.test(url);
+    if(!result){
+        let pat2 = new RegExp("^/");
+        let result2 = pat2.test(url);
+        if(result2){
+            url = host+url;
+            
+        }else{
+            url =host+"/"+url;
+        }
+        
+    }
+    return url;
+}
 
 module.exports = {
     strDiscode:strDiscode,
-    urlToHttpUrl:urlToHttpUrl
+    urlToHttpUrl:urlToHttpUrl,
+    urlAddHost:urlAddHost
 }


### PR DESCRIPTION
使用中发现用富文本编辑器生成的html代码里的图片地址，都是相对地址，没有host，所以自己修改代码支持能在代码中添加固定的host地址，原来有个
 imgUrl = wxDiscode.urlToHttpUrl(imgUrl, __placeImgeUrlHttps);
这有点搞不懂这在干嘛，没有修改，目前应用中没影响，麻烦作者说下这方法是干嘛的，谢谢了