### PR TITLE
解决 calMoreImageInfo函数报错问题

### DIFF
--- a/wxParse/wxParse.js
+++ b/wxParse/wxParse.js
@@ -70,7 +70,7 @@ function wxParseImgLoad(e) {
 // 假循环获取计算图片视觉最佳宽高
 function calMoreImageInfo(e, idx, that, bindName) {
   var temData = that.data[bindName];
-  if (temData.images.length == 0) {
+  if (!temData || temData.images.length == 0) {
     return;
   }
   var temImages = temData.images;


### PR DESCRIPTION
报错：
Cannot read property 'images' of undefined;at "pages/detail/detail" page wxParseImgLoad function
TypeError: Cannot read property 'images' of undefined

加了个不存在的return情况 
if (!temData || temData.images.length == 0) {
    return;
  }