### PR TITLE
添加了wxParse-figure样式

### DIFF
--- a/wxParse/wxParse.wxss
+++ b/wxParse/wxParse.wxss
@@ -201,3 +201,6 @@ view{
 .wxParse-del{
     display: inline;
 }
+.wxParse-figure {
+  overflow: hidden;
+}


### PR DESCRIPTION
我们前端使用的是trix，当上传图片之后，在微信小程序上显示的图片超出了屏幕范围，没有padding