### PR TITLE
fixed 图片大小不正确 & fixed result is not defined

### DIFF
--- a/wxParse/html2json.js
+++ b/wxParse/html2json.js
@@ -55,7 +55,7 @@ function removeDOCTYPE(html) {
 
 function trimHtml(html) {
   return html
-        .replace(/\n+/g, '')
+        .replace(/\r?\n+/g, '')
         .replace(/<!--.*?-->/ig, '')
         .replace(/\/\*.*?\*\//ig, '')
         .replace(/[ ]+</ig, '<')
@@ -227,6 +227,8 @@ function html2json(html, bindName) {
             };
             
             if (bufArray.length === 0) {
+                node.index = index.toString()
+                index += 1
                 results.nodes.push(node);
             } else {
                 var parent = bufArray[0];

--- a/wxParse/html2json.js
+++ b/wxParse/html2json.js
@@ -205,7 +205,7 @@ function html2json(html, bindName) {
             //当有缓存source资源时于于video补上src资源
             if(node.tag === 'video' && results.source){
                 node.attr.src = results.source;
-                delete result.source;
+                delete results.source;
             }
             
             if (bufArray.length === 0) {


### PR DESCRIPTION
1. fixed #131 
`\n` 去掉了，但是`\r` 留着，整个nodes 还是很大

其实图片大小不正确的最主要原因是因为当node为`text` 的时候，没有index
所以后面`calMoreImageInfo` 时设置with/height 使用`index`来定位会出错；如果只是`trimHtml`的话，当真的有text 节点，图片宽高还是会有问题。
例如：
```
<p><img src="https://mp.weixin.qq.com/debug/wxadoc/dev/image/cat/0.jpg?t=2017727" alt="demo" /></p>
<p><img src="https://mp.weixin.qq.com/debug/wxadoc/dev/image/cat/0.jpg?t=2017727" alt="demo" /></p>我是一段文字我是一段文字我是一段文字我是一段文字我是一段文字
<p>结束语</p>
```
2. fixed  result is not defined, change `delete result.source` to `delete results.source`