### PR TITLE
fixed bug #191 多数据循环图片宽高问题，完善多数据调用方法

### DIFF
--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -160,12 +160,12 @@ Page({
 	</div>`;
     var replyHtml1 = `<div style="margin-top:10px;height:50px;">
 		<p class="reply">
-			wxParse回复1:不错，喜欢[03][04]
+			wxParse回复1:不错，喜欢[03][04]<img src="../../image/icon_API.png"/>
 		</p>	
 	</div>`;
     var replyHtml2 = `<div style="margin-top:10px;height:50px;">
 		<p class="reply">
-			wxParse回复2:不错，喜欢[05][07]
+			wxParse回复2:不错，喜欢[05][07]<img src="../../image/icon_API_HL.png"/>
 		</p>	
 	</div>`;
     var replyHtml3 = `<div style="margin-top:10px;height:50px;">
@@ -193,10 +193,7 @@ Page({
 
 
     for (let i = 0; i < replyArr.length; i++) {
-      WxParse.wxParse('reply' + i, 'html', replyArr[i], that);
-      if (i === replyArr.length - 1) {
-        WxParse.wxParseTemArray("replyTemArray",'reply', replyArr.length, that)
-      }
+      WxParse.wxParse('replyTemArray.' + i, 'html', replyArr[i], that);
     }
   }
 

--- a/pages/index/index.wxml
+++ b/pages/index/index.wxml
@@ -6,6 +6,6 @@
 
 <view style="padding: 20px 10px; background-color:#eee;">
     <block wx:for="{{replyTemArray}}" wx:key="">
-        回复{{index}}:<template is="wxParse" data="{{wxParseData:item}}"/>
+        回复{{index}}:<template is="wxParse" data="{{wxParseData:item.nodes}}"/>
     </block>
 </view>

--- a/wxParse/wxParse.js
+++ b/wxParse/wxParse.js
@@ -33,7 +33,7 @@ function wxParse(bindName = 'wxParseData', type='html', data='<div class="color:
   var transData = {};//存放转化后的数据
   if (type == 'html') {
     transData = HtmlToJson.html2json(data, bindName);
-    console.log(JSON.stringify(transData, ' ', ' '));
+    // console.log(JSON.stringify(transData, ' ', ' '));
   } else if (type == 'md' || type == 'markdown') {
     var converter = new showdown.Converter();
     var html = converter.makeHtml(data);
@@ -77,7 +77,7 @@ function wxParseImgLoad(e) {
 }
 // 假循环获取计算图片视觉最佳宽高
 function calMoreImageInfo(e, idx, that, bindName) {
-  var temData = that.data[bindName];
+  var temData = getData(bindName,that.data);
   if (!temData || temData.images.length == 0) {
     return;
   }
@@ -107,7 +107,7 @@ function wxAutoImageCal(originalWidth, originalHeight,that,bindName) {
   var windowWidth = 0, windowHeight = 0;
   var autoWidth = 0, autoHeight = 0;
   var results = {};
-  var padding = that.data[bindName].view.imagePadding;
+  var padding = getData(bindName,that.data).view.imagePadding;
   windowWidth = realWindowWidth-2*padding;
   windowHeight = realWindowHeight;
   //判断按照那种方式进行缩放
@@ -139,6 +139,32 @@ function wxParseTemArray(temArrayName,bindNameReg,total,that){
   obj = JSON.parse('{"'+ temArrayName +'":""}');
   obj[temArrayName] = array;
   that.setData(obj);
+}
+
+// 获取对象实例的属性值，支持多级用“.”隔开
+function getData(key, obj) {
+  debugger
+  if (!obj) 
+    console.error('obj is invalid:', obj);
+  var ka = key.split(/\./);
+  var key1 = ka.shift();
+
+  // 为了兼容旧的写法（xxxxx[x]）添加以下转换
+  var arrayNameReg = /^([a-zA-Z0-9_-]+)\[([0-9]+)\]$/;
+  if (arrayNameReg.test(key1)){
+    var nameValues = key1.match(arrayNameReg)
+    key1 = nameValues[1]
+    var index = nameValues[2]
+    ka.unshift(index)
+  }
+  // 兼容写法结束
+
+  if (ka.length < 1) {
+    return obj[key1];
+  } else {
+    obj = obj[key1];
+    return getData(ka.join("."), obj);
+  }
 }
 
 /**


### PR DESCRIPTION
1. 设置图片宽高时，bindName支持多级读取，用“.”分隔。
2. 修改图片宽高设置逻辑，
3. 可以不再调用 wxParseTemArray 方法。
4. 保持用法一致（多数据和单数据）：wxml中需要加.nodes