### PR TITLE
Fix: <img /> 中无 src 属性抛错

### DIFF
--- a/wxParse/html2json.js
+++ b/wxParse/html2json.js
@@ -147,8 +147,8 @@ function html2json(html, bindName) {
             //对img添加额外数据
             if (node.tag === 'img') {
                 node.imgIndex = results.images.length;
-                var imgUrl = node.attr.src;
-                if (imgUrl[0] == '') {
+                var imgUrl = node.attr.src || node.attr['data-src'];
+                if (imgUrl && imgUrl[0] == '') {
                     imgUrl.splice(0, 1);
                 }
                 imgUrl = wxDiscode.urlToHttpUrl(imgUrl, __placeImgeUrlHttps);


### PR DESCRIPTION
有的 HTML 中，<img /> 中图片链接使用的是自定义属性 data-src，如果 img 标签中无 src 属性，会抛错。

所以加上了判断，如果没有 node.attr.src 则取 node.attr['data-src']。

#203