### PR TITLE
[bugfix] Replace console.dir to console.log

### DIFF
--- a/wxParse/html2json.js
+++ b/wxParse/html2json.js
@@ -109,14 +109,14 @@ function html2json(html, bindName) {
                     var name = attr.name;
                     var value = attr.value;
                     if (name == 'class') {
-                        console.dir(value);
+                        console.log(value);
                         //  value = value.join("")
                         node.classStr = value;
                     }
                     // has multi attibutes
                     // make it array of attribute
                     if (name == 'style') {
-                        console.dir(value);
+                        console.log(value);
                         //  value = value.join("")
                         node.styleStr = value;
                     }


### PR DESCRIPTION
`console.dir()` method doesn't exist in Android wechat, it will throw error when html have `class` or `style` attribute. 

Close issue #220  #230 #242 #266 #267 #287 #290 when pr merged.