### PR TITLE
Update wxParse.wxml

### DIFF
--- a/wxParse/wxParse.wxml
+++ b/wxParse/wxParse.wxml
@@ -18,7 +18,7 @@
 </template>
 
 <template name="wxParseImg">
-  <image class="{{item.classStr}} wxParse-{{item.tag}}" data-from="{{item.from}}" data-src="{{item.attr.src}}" data-idx="{{item.imgIndex}}" src="{{item.attr.src}}" mode="aspectFit" bindload="wxParseImgLoad" bindtap="wxParseImgTap" mode="widthFix" style="width:{{item.width}}px;"
+  <image class="{{item.classStr}} wxParse-{{item.tag}}" data-from="{{item.from}}" data-src="{{item.attr.src}}" data-idx="{{item.imgIndex}}" src="{{item.attr.src}}" mode="aspectFit" bindload="wxParseImgLoad" bindtap="wxParseImgTap" mode="widthFix" style="{{item.styleStr}}"
   />
 </template>
 


### PR DESCRIPTION
修复解析后的图片的style不根据原HTML的style而改变
<template name="wxParseImg">里的
style="width:{{item.width}}px;"变为style="{{item.styleStr}}"