### PR TITLE
feat: remove <style></style> 标签信息

### DIFF
--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -45,7 +45,12 @@ Page({
 			<video src="http://wxsnsdy.tc.qq.com/105/20210/snsdyvideodownload?filekey=30280201010421301f0201690402534804102ca905ce620b1241b726bc41dcff44e00204012882540400&bizid=1023&hy=SH&fileparam=302c020101042530230204136ffd93020457e3c4ff02024ef202031e8d7f02030f42400204045a320a0201000400"></video>
 		</div>
 	</div>
-	
+
+	<style type="text/css">
+	body{
+		padding: 4px;
+	}
+	</style>
 
 	<div style="margin-top:10px;">
 		<h3 style="color: #000;">支持的标签</h3>

--- a/wxParse/html2json.js
+++ b/wxParse/html2json.js
@@ -53,6 +53,15 @@ function removeDOCTYPE(html) {
         .replace(/<.*!DOCTYPE.*\>\n/, '');
 }
 
+/**
+ * 去除富文本字符串中的 style 标签
+ * @param {String} html 富文本字符串
+ */
+function removeStyleCss(html) {
+    return html
+        .replace(/\<style(.|\n)*\<\/style\>/gm, '');
+}
+
 function trimHtml(html) {
   return html
         .replace(/\r?\n+/g, '')
@@ -61,11 +70,21 @@ function trimHtml(html) {
         .replace(/[ ]+</ig, '<')
 }
 
+/**
+ * 对富文本的某些特殊信息进行过滤
+ * @param {String} html 富文本字符串
+ */
+function filterHtml(html){
+    html = removeDOCTYPE(html);
+    html = removeStyleCss(html);
+    html = trimHtml(html);
+    return html
+}
+
 
 function html2json(html, bindName) {
     //处理字符串
-    html = removeDOCTYPE(html);
-    html = trimHtml(html);
+    html = filterHtml(html);
     html = wxDiscode.strDiscode(html);
     //生成node节点
     var bufArray = [];


### PR DESCRIPTION

由于运营在使用富文本编辑器的时候会通过在其它地方拷贝内容的方式进行文章编辑，所以极有可能会将 `<style></style>` 粘贴进富文本编辑器。  

`wxParse` 在解析含有 `<style></style>`  信息的富文本字符串时，`<style></style>` 内容会被当做 text 进行解析，影响页面内容展示，所以需要过滤掉 `<style></style>` 信息。  

![image](https://user-images.githubusercontent.com/18358407/57193354-b0826f00-6f6c-11e9-9fc9-4aa37117cc80.png)
